### PR TITLE
fix: change localhost to 127.0.0.1 in callback url

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ options:
                         Exclude playlists by their URI in the format spotify:playlist:<base62-encoded id>. Can be repeated for multiple playlists. This option is evaluated last and overrides all other inclusion rules
 
 Get client ID and secret at https://developer.spotify.com/dashboard/applications.
-Add http://localhost:30700/callback to Redirect URIs in settings of your application.
+Add http://127.0.0.1:30700/callback to Redirect URIs in settings of your application.
 ```
 
-Don't forget to add `http://localhost:30700/callback` to Redirect URIs in settings of your application.
+Don't forget to add `http://127.0.0.1:30700/callback` to Redirect URIs in settings of your application.
 
 P.s. run with ``--help`` for actual usage as above may be out of date.
 

--- a/spotify_dumper/main.py
+++ b/spotify_dumper/main.py
@@ -229,7 +229,7 @@ def write_output(f: TextIO, output: list[Any], args: argparse.Namespace) -> None
 parser = argparse.ArgumentParser(
     description="Dump spotify playlists to JSON file.\n",
     epilog="Get client ID and secret at https://developer.spotify.com/dashboard/applications.\n"
-           "Add http://localhost:30700/callback to Redirect URIs in settings of your application.",
+           "Add http://127.0.0.1:30700/callback to Redirect URIs in settings of your application.",
     formatter_class=argparse.RawTextHelpFormatter
 )
 

--- a/spotify_dumper/spotify.py
+++ b/spotify_dumper/spotify.py
@@ -12,6 +12,7 @@ from requests import Session
 
 Json = dict[str, Any]
 
+
 class SpotifyAPI:
     token_deadline: Optional[float]
     access_token: Optional[str]
@@ -25,15 +26,14 @@ class SpotifyAPI:
         self.client_id = client_id
         self.client_secret = client_secret
         self.listen_port = listen_port
-        self.client_id_header = "Basic " + base64.b64encode(f"{self.client_id}:{self.client_secret}".encode("utf-8")) \
-            .decode("utf-8")
+        self.client_id_header = "Basic " + base64.b64encode(
+            f"{self.client_id}:{self.client_secret}".encode("utf-8")
+        ).decode("utf-8")
 
     @classmethod
     def new(
-        cls, listen_port: int, client_id: Optional[str] = None, client_secret: Optional[str] = None,
-        keep: bool = False
+        cls, listen_port: int, client_id: Optional[str] = None, client_secret: Optional[str] = None, keep: bool = False
     ) -> Self:
-
         if os.path.exists("data.json"):
             with open("data.json") as f:
                 data = json.load(f)
@@ -70,7 +70,7 @@ class SpotifyAPI:
         return {
             "access_token": self.access_token,
             "refresh_token": self.refresh_token,
-            "token_deadline": self.token_deadline
+            "token_deadline": self.token_deadline,
         }
 
     def auth(self) -> None:
@@ -81,7 +81,7 @@ class SpotifyAPI:
                     "response_type": "code",
                     "client_id": self.client_id,
                     "scope": "playlist-read-private playlist-read-collaborative user-library-read",
-                    "redirect_uri": f"http://localhost:{self.listen_port}/callback",
+                    "redirect_uri": f"http://127.0.0.1:{self.listen_port}/callback",
                 }
             )
         )
@@ -90,7 +90,7 @@ class SpotifyAPI:
         # no library lets you handle request in-place.
         with socket.socket() as sock:
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind(('127.0.0.1', self.listen_port))
+            sock.bind(("127.0.0.1", self.listen_port))
             sock.listen()
             while True:
                 sock2, _ = sock.accept()
@@ -114,9 +114,9 @@ class SpotifyAPI:
                         b"HTTP/1.0 200 OK\r\n"
                         b"Content-Type: text/html\r\n"
                         b"\r\n"
-                        b'<script>close()</script>You can close this window.'
+                        b"<script>close()</script>You can close this window."
                     )
-                    capture = re.search('code=([^&]+)', path)
+                    capture = re.search("code=([^&]+)", path)
                     if capture:
                         code = capture.group(1)
                         break
@@ -127,13 +127,10 @@ class SpotifyAPI:
                 {
                     "grant_type": "authorization_code",
                     "code": code,
-                    "redirect_uri": f"http://localhost:{self.listen_port}/callback",
+                    "redirect_uri": f"http://127.0.0.1:{self.listen_port}/callback",
                 }
             ),
-            headers={
-                "Content-Type": "application/x-www-form-urlencoded",
-                "Authorization": self.client_id_header
-            }
+            headers={"Content-Type": "application/x-www-form-urlencoded", "Authorization": self.client_id_header},
         )
         resp.raise_for_status()
         data = resp.json()
@@ -144,16 +141,8 @@ class SpotifyAPI:
     def refresh(self) -> None:
         resp = self.session.post(
             "https://accounts.spotify.com/api/token",
-            data=urllib.parse.urlencode(
-                {
-                    "grant_type": "refresh_token",
-                    "refresh_token": self.refresh_token
-                }
-            ),
-            headers={
-                "Content-Type": "application/x-www-form-urlencoded",
-                "Authorization": self.client_id_header
-            }
+            data=urllib.parse.urlencode({"grant_type": "refresh_token", "refresh_token": self.refresh_token}),
+            headers={"Content-Type": "application/x-www-form-urlencoded", "Authorization": self.client_id_header},
         )
         resp.raise_for_status()
         data = resp.json()
@@ -163,13 +152,12 @@ class SpotifyAPI:
     def get(self, path: str, params: Optional[dict[str, Any]] = None) -> Json:
         if params is None:
             params = {}
-        url = path if path.startswith("https://api.spotify.com/v1/") \
+        url = (
+            path
+            if path.startswith("https://api.spotify.com/v1/")
             else "https://api.spotify.com/v1/" + path.removeprefix("/")
-        resp = self.session.get(
-            url,
-            headers={"Authorization": f"Bearer {self.access_token}"},
-            params=params
         )
+        resp = self.session.get(url, headers={"Authorization": f"Bearer {self.access_token}"}, params=params)
         resp.raise_for_status()
         return resp.json()
 
@@ -180,8 +168,9 @@ class SpotifyAPI:
         yield response
 
         while response["next"]:
-            response = self.get(response['next'])
+            response = self.get(response["next"])
             yield response
+
 
 class NoApiPairError(Exception):
     pass


### PR DESCRIPTION
Hi since the 9th of April 2025  https://developer.spotify.com/documentation/web-api/concepts/redirect_uri the only valid http url accepted for callbacks is for 127.0.0.1, localhost is not accepted anymore.
This PR fixes this by using 127.0.0.1 instead of localhost in callback.