### PR TITLE
fix F-literal, add custom proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ options:
                         Include additional playlists by their URI in the format spotify:playlist:<base62-encoded id>. Can be repeated for multiple playlists
   -x URI, --exclude URI
                         Exclude playlists by their URI in the format spotify:playlist:<base62-encoded id>. Can be repeated for multiple playlists. This option is evaluated last and overrides all other inclusion rules
+  -p PROXY, --proxy PROXY
+                        Connect to Spotify API through an HTTP(S) proxy (e.g. http://127.0.0.1:1080). Has no effect on your browser.
+                        You can also try using a SOCKS proxy if you know exactly which dependencies need to be installed.
 
 Get client ID and secret at https://developer.spotify.com/dashboard/applications.
 Add http://127.0.0.1:30700/callback to Redirect URIs in settings of your application.

--- a/spotify_dumper/main.py
+++ b/spotify_dumper/main.py
@@ -99,7 +99,7 @@ def main() -> None:
     with console.status("Authorizing in spotify"):
         try:
             spotify = SpotifyAPI.new(
-                client_id=args.client_id, client_secret=args.client_secret, listen_port=args.listen_port, keep=args.keep
+                client_id=args.client_id, client_secret=args.client_secret, listen_port=args.listen_port, keep=args.keep, proxy=args.proxy
             )
         except NoApiPairError:
             console.print("No client id/secret provided! Use --client-id and --client-secret arguments.")
@@ -125,7 +125,7 @@ def main() -> None:
                     continue
                 try:
 
-                    playlist = spotify.get(f"/playlists/{uri.removeprefix("spotify:playlist:")}")
+                    playlist = spotify.get(f"/playlists/{uri.removeprefix('spotify:playlist:')}")
                 except HTTPError as e:
                     if e.response.status_code == 404:
                         console.print(f"Playlist {uri} does not exist!", style="red")
@@ -247,6 +247,11 @@ parser.add_argument(
     "--listen-port", dest="listen_port", type=int, default=30700,
     help="For advanced users. Change port of internal HTTP server that is responsible for taking auth code."
 )
+parser.add_argument(
+    "-p", "--proxy", dest="proxy", type=str,
+    help=   "Connect to Spotify API through an HTTP(S) proxy (e.g. http://127.0.0.1:1080). Has no effect on your browser.\n"
+            "You can also try using a SOCKS proxy if you know exactly which dependencies need to be installed."
+)
 
 # Output
 parser.add_argument("--overwrite", dest="overwrite", action="store_true", help="Overwrite destination file.")
@@ -275,7 +280,6 @@ parser.add_argument(
     "-x", "--exclude", dest="excluded_playlist_uris", action="append", metavar="URI",
     help="Exclude playlists by their URI in the format spotify:playlist:<base62-encoded id>. Can be repeated for multiple playlists. This option is evaluated last and overrides all other inclusion rules"
 )
-
 
 
 if __name__ == "__main__":

--- a/spotify_dumper/spotify.py
+++ b/spotify_dumper/spotify.py
@@ -17,7 +17,7 @@ class SpotifyAPI:
     access_token: Optional[str]
     refresh_token: Optional[str]
 
-    def __init__(self, client_id: str, client_secret: str, listen_port: int):
+    def __init__(self, client_id: str, client_secret: str, listen_port: int, proxy: str):
         self.session = Session()
         self.access_token = None
         self.refresh_token = None
@@ -27,11 +27,13 @@ class SpotifyAPI:
         self.listen_port = listen_port
         self.client_id_header = "Basic " + base64.b64encode(f"{self.client_id}:{self.client_secret}".encode("utf-8")) \
             .decode("utf-8")
+        
+        self.proxies = {'http': proxy, 'https': proxy}
 
     @classmethod
     def new(
         cls, listen_port: int, client_id: Optional[str] = None, client_secret: Optional[str] = None,
-        keep: bool = False
+        keep: bool = False, proxy: Optional[str] = None
     ) -> Self:
 
         if os.path.exists("data.json"):
@@ -46,7 +48,7 @@ class SpotifyAPI:
         if client_id is None or client_secret is None:
             raise NoApiPairError
 
-        res = cls(listen_port=listen_port, client_id=client_id, client_secret=client_secret)
+        res = cls(listen_port=listen_port, client_id=client_id, client_secret=client_secret, proxy=proxy)
         if data:
             res.restore(data)
         else:
@@ -133,7 +135,7 @@ class SpotifyAPI:
             headers={
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Authorization": self.client_id_header
-            }
+            }, proxies=self.proxies
         )
         resp.raise_for_status()
         data = resp.json()
@@ -153,7 +155,7 @@ class SpotifyAPI:
             headers={
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Authorization": self.client_id_header
-            }
+            }, proxies=self.proxies
         )
         resp.raise_for_status()
         data = resp.json()
@@ -168,7 +170,7 @@ class SpotifyAPI:
         resp = self.session.get(
             url,
             headers={"Authorization": f"Bearer {self.access_token}"},
-            params=params
+            params=params, proxies=self.proxies
         )
         resp.raise_for_status()
         return resp.json()


### PR DESCRIPTION
Do I need to explain anything?
Anyway, besides adding an argument for using a custom proxy, I also fixed incorrect F-literal quotes that raised `SyntaxError: f-string: unmatched (`.